### PR TITLE
feat(kali): switch to non-root user

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -58,16 +58,14 @@ jobs:
           for label in build chore ci docs feat fix perf refactor test style ; do
             if [[ "${label}" == "${type}" ]]; then
               echo "Label to add: ${label}"
-              # shellcheck disable=SC2076
-              if [[ "${PR_LABELS}" =~ "\"${label}\"" ]] ; then
+              if [[ "${PR_LABELS}" == *"${label}"* ]] ; then
                 echo "Label ${label} already present"
               else
                 add_labels+=("${label}")
               fi
             else
               echo "Label to remove: ${label}"
-              # shellcheck disable=SC2076
-              if [[ "${PR_LABELS}" =~ "\"${label}\"" ]] ; then
+              if [[ "${PR_LABELS}" == *"${label}"* ]] ; then
                 remove_labels+=("${label}")
               else
                 echo "Label ${label} not present"
@@ -78,8 +76,7 @@ jobs:
           regexp2='^[a-zA-Z0-9]+\([a-zA-Z0-9\-]*deps\)$'
           if [[ "${scoped_type}" =~ ${regexp2} ]] ; then
             echo "Label to add: dependencies"
-            # shellcheck disable=SC2076
-            if [[ "${PR_LABELS}" =~ "\"dependencies\"" ]] ; then
+            if [[ "${PR_LABELS}" == *"dependencies"* ]] ; then
               echo "Label dependencies already present"
             else
               add_labels+=('dependencies')
@@ -93,16 +90,14 @@ jobs:
                 || "${type}" == 'style' \
                 || "${type}" == 'test' ]] ; then
             echo "Label to add: no-release-notes"
-            # shellcheck disable=SC2076
-            if [[ "${PR_LABELS}" =~ "\"no-release-notes\"" ]] ; then
+            if [[ "${PR_LABELS}" == *"no-release-notes"* ]] ; then
               echo "Label no-release-notes already present"
             else
               add_labels+=('no-release-notes')
             fi
           else
             echo "Label to remove: no-release-notes"
-            # shellcheck disable=SC2076
-            if [[ "${PR_LABELS}" =~ "\"no-release-notes\"" ]] ; then
+            if [[ "${PR_LABELS}" == *"no-release-notes"* ]] ; then
               remove_labels+=('no-release-notes')
             else
               echo "Label no-release-notes not present"

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -1,13 +1,14 @@
-# checkov:skip=CKV_DOCKER_3
-# checkov:skip=CKV_DOCKER_7
-# hadolint ignore=DL3007
-# trivy:ignore:AVD-DS-0001
-# trivy:ignore:AVD-DS-0002
+# hadolint ignore=DL3007 # checkov:skip=CKV_DOCKER_7 # trivy:ignore:AVD-DS-0001 # [Don't use latest]: no tagged version available
 FROM kalilinux/kali-rolling:latest
 
 HEALTHCHECK NONE
 
 ENTRYPOINT []
+
+ARG USER_NAME=kali
+ARG USER_HOME=/home/kali
+ARG USER_ID=1000
+ARG USER_GECOS=kali
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -33,3 +34,16 @@ RUN apt-get update \
       wget=1.25.0-2 \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+RUN adduser \
+  --home "${USER_HOME}" \
+  --uid "${USER_ID}" \
+  --gecos "${USER_GECOS}" \
+  --disabled-password \
+  "${USER_NAME}"
+
+USER "${USER_NAME}"
+
+ENV HOME="${USER_HOME}"
+
+WORKDIR "${HOME}"

--- a/kali/docker-compose.test.yml
+++ b/kali/docker-compose.test.yml
@@ -8,7 +8,7 @@ services:
       sh -c '
         set -euo pipefail
         # Use $$ to prevent interpolation 
-        if [ $$(id -u) -ne 0 ]; then
+        if [ $$(id -u) -ne 1000 ]; then
           exit 1
         fi
         curl --version # curl


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

Please check the boxes below to confirm that you have followed the
required guidelines for contributions:

- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification).
- [x] The title for this pull request is the same as the first commit's message and it follows the [conventional commits specification](https://www.conventionalcommits.org). See commit history for examples.
- [x] If this pull request includes code changes, they were all properly tested. Automated tests were also included where possible.
- [x] If applicable, this pull request includes the relevant documentation for this change.
- [x] If this pull request is related to an existing issue, you can use the same description below but in any case include a [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like `Fixes #ISSUE_NUMBER.` or `Closes #ISSUE_NUMBER.`.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Description

It is generally considered a security best practice not to run a Docker container as `root`. By default the `kalilinux/kali-rolling` is using `root` but it is meant to be extended and customized and as such `leplusorg/kali` should make its image adhere the security best practices.

### Benefits

It will improve the security of the image and in particular if it is used in automated environment (e.g. CI/CD pipelines), it will reduce the blast radius in case someone tries to exploit the image for malicious purposes.

### Drawbacks

Some tools may require root permissions to run. We will ensure that it is not the case for the tools that are included in the `leplusorg/kali` image. If someone needs to add a tool that require root privileges, then they can build their image on top of `leplusorg/kali`, add the desired package and configure `sudo`. Although it might feel cumbersome to have to do this, making the image more secure by default and only allowing a more risky configuration if/when needed seems like the best approach.

<!-- prettier-ignore-end -->
